### PR TITLE
Peg in hole

### DIFF
--- a/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system.hpp
+++ b/mujoco_ros2_control/include/mujoco_ros2_control/mujoco_system.hpp
@@ -84,6 +84,7 @@ public:
 private:
   void register_joints(const urdf::Model& urdf_model, const hardware_interface::HardwareInfo & hardware_info);
   void register_sensors(const urdf::Model& urdf_model, const hardware_interface::HardwareInfo & hardware_info);
+  void set_initial_pose();
   void get_joint_limits(urdf::JointConstSharedPtr urdf_joint, joint_limits::JointLimits& joint_limits);
   control_toolbox::Pid get_pid_gains(const hardware_interface::ComponentInfo& joint_info, std::string command_interface);
   double clamp(double v, double lo, double hi)

--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -35,13 +35,13 @@ hardware_interface::return_type MujocoSystem::read(const rclcpp::Time & time, co
   // FT Sensor data
   for (auto& data : ft_sensor_data_)
   {
-    data.force.data.x() = mj_data_->sensordata[data.force.mj_sensor_index];
-    data.force.data.y() = mj_data_->sensordata[data.force.mj_sensor_index + 1];
-    data.force.data.z() = mj_data_->sensordata[data.force.mj_sensor_index + 2];
+    data.force.data.x() = -mj_data_->sensordata[data.force.mj_sensor_index];
+    data.force.data.y() = -mj_data_->sensordata[data.force.mj_sensor_index + 1];
+    data.force.data.z() = -mj_data_->sensordata[data.force.mj_sensor_index + 2];
 
-    data.torque.data.x() = mj_data_->sensordata[data.torque.mj_sensor_index];
-    data.torque.data.y() = mj_data_->sensordata[data.torque.mj_sensor_index + 1];
-    data.torque.data.z() = mj_data_->sensordata[data.torque.mj_sensor_index + 2];
+    data.torque.data.x() = -mj_data_->sensordata[data.torque.mj_sensor_index];
+    data.torque.data.y() = -mj_data_->sensordata[data.torque.mj_sensor_index + 1];
+    data.torque.data.z() = -mj_data_->sensordata[data.torque.mj_sensor_index + 2];
   }
 }
 
@@ -113,6 +113,7 @@ bool MujocoSystem::init_sim(rclcpp::Node::SharedPtr& node, mjModel* mujoco_model
   register_sensors(urdf_model,hardware_info);
 
   // TODO: set initial pose
+  set_initial_pose();
   return true;
 }
 
@@ -328,6 +329,16 @@ void MujocoSystem::register_sensors(const urdf::Model& urdf_model, const hardwar
         state_interfaces_.emplace_back(sensor.name, state_if.name, &last_sensor_data.torque.data.z());
       }
     }
+  }
+}
+
+void MujocoSystem::set_initial_pose()
+{
+  // Assuming 
+  // Joint states
+  for (auto& joint_state : joint_states_)
+  {
+    mj_data_->qpos[joint_state.mj_pos_adr] = joint_state.position_command;
   }
 }
 

--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -334,11 +334,9 @@ void MujocoSystem::register_sensors(const urdf::Model& urdf_model, const hardwar
 
 void MujocoSystem::set_initial_pose()
 {
-  // Assuming 
-  // Joint states
   for (auto& joint_state : joint_states_)
   {
-    mj_data_->qpos[joint_state.mj_pos_adr] = joint_state.position_command;
+    mj_data_->qpos[joint_state.mj_pos_adr] = joint_state.position;
   }
 }
 

--- a/mujoco_ros2_control/src/mujoco_system.cpp
+++ b/mujoco_ros2_control/src/mujoco_system.cpp
@@ -112,7 +112,6 @@ bool MujocoSystem::init_sim(rclcpp::Node::SharedPtr& node, mjModel* mujoco_model
   register_joints(urdf_model, hardware_info);
   register_sensors(urdf_model,hardware_info);
 
-  // TODO: set initial pose
   set_initial_pose();
   return true;
 }


### PR DESCRIPTION
Modifications to implement peg-in-hole example.
Add functionality to set the initial pose and reverse the sign of the FT sensors.